### PR TITLE
Use AIS for initial address lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,8 @@
 
     <!-- Property Row View Template for Multiple Properties -->
     <script type="text/template" id="tmpl-search-results-row">
-        <a href="#view/<%= data.searchResultsRow.account_number %>"><%= data.searchResultsRow.full_address %><% if(data.searchResultsRow.unit) { %> <span class="unit"><%= D("unit") %> : <%= data.searchResultsRow.unit %></span><% } %></a>
+        <!-- <a href="#view/<%= data.searchResultsRow.properties.opa_account_num %>"><%= data.searchResultsRow.properties.street_address %></a> -->
+        <a href="#view/<%= data.searchResultsRow.properties.opa_account_num %>"><%= data.searchResultsRow.properties.street_address %></a>
     </script>
 
     <!-- Error View Template -->

--- a/js/app.js
+++ b/js/app.js
@@ -71,6 +71,7 @@ window.Backbone = window.Backbone || {};
     app.Collections.SearchResults = Backbone.Collection.extend({
         settings: {
             apiHost: "http://api.phila.gov/ais/v1/"
+            ,apiKey: 'a7fcb40dbf4ed265f9d5cf3d68d64b62'
             ,skip: 0
             ,limit: 30
         }
@@ -81,7 +82,10 @@ window.Backbone = window.Backbone || {};
             this.limit = this.settings.limit;
         }
         ,url: function() {
-            return this.settings.apiHost + this.method + "/" + this.input + "/?limit=" + this.limit + "&skip=" + this.skip + '&include_units&opa_only';
+            return this.settings.apiHost + this.method + "/" + this.input +
+                   "/?limit=" + this.limit + "&skip=" + this.skip +
+                   '&include_units&opa_only&gatekeeperKey=' + 
+                   this.settings.apiKey;
         }
         ,parse: function(response, options) {
             this.moreAvailable = response.total_size > this.length + response.features.length;

--- a/js/app.js
+++ b/js/app.js
@@ -84,7 +84,7 @@ window.Backbone = window.Backbone || {};
         ,url: function() {
             return this.settings.apiHost + this.method + "/" + this.input +
                    "/?limit=" + this.limit + "&skip=" + this.skip +
-                   '&include_units&opa_only&gatekeeperKey=' + 
+                   '&include_units&opa_only&gatekeeperKey=' +
                    this.settings.apiKey;
         }
         ,parse: function(response, options) {
@@ -101,7 +101,8 @@ window.Backbone = window.Backbone || {};
                 var features = _.filter(response.features, function (feature) {
                   // ignore ais "parsed" results (aka addresses that have
                   // been parsed but don't exist)
-                  return feature.match_type != 'parsed';
+                  var matchType = feature.match_type;
+                  return !(matchType == 'parsed' || matchType === 'unmatched');
                 });
                 if(response.status === "error" || ! features.length) {
                     oldOptions.error({status: 404});

--- a/js/app.js
+++ b/js/app.js
@@ -4,7 +4,7 @@ window.jQuery = window.jQuery || {};
 window._ = window._ || {};
 window.Backbone = window.Backbone || {};
 (function(window, $, _, Backbone, app, util) {
-    
+
     /**
      * Config
      * TODO: Override backbone ajax with jquery-jsonp
@@ -14,7 +14,7 @@ window.Backbone = window.Backbone || {};
     _.templateSettings.variable = "data"; // Namespace for template data
     $.ajaxSetup({cache: true, timeout: 15000}); // Cache ajax requests (used by typeahead)
     app.language = $.cookie("language") || "en";
-    
+
     /**
      * If no CORS support, use jquery-jsonp library for ajax
      */
@@ -27,7 +27,7 @@ window.Backbone = window.Backbone || {};
         }
         return Backbone.$.ajax.apply(Backbone.$, arguments);
     };
-    
+
     app.Models.Property = Backbone.Model.extend({
         settings: {
             apiHost: "http://api.phila.gov/opa/v1.1/"
@@ -36,11 +36,12 @@ window.Backbone = window.Backbone || {};
             this.input = options.input || "";
         }
         ,url: function() {
-            return this.settings.apiHost + "account/" + this.input + "?format=json";
+            var url = this.settings.apiHost + "account/" + this.input + "?format=json";
+            return url;
         }
         ,parse: function(response, options) {
             var property = response.data.property;
-            
+
             // If proposed valuation has data, use that as the "new value"; otherwise, use valuation history for values
             if( ! _.isEmpty(property.proposed_valuation)) {
                 property.new_value = property.proposed_valuation;
@@ -50,7 +51,7 @@ window.Backbone = window.Backbone || {};
                 property.new_value = property.valuation_history[0];
                 property.previous_value = property.valuation_history[1];
             }
-            
+
             // If previous value year is < 2014 (prior to AVI), divide the values by 32% to get taxable market value
             if(parseInt(property.previous_value.certification_year, 0) < 2014) {
                 property.previous_value.land_taxable /= .32;
@@ -58,33 +59,33 @@ window.Backbone = window.Backbone || {};
                 property.previous_value.improvement_taxable /= .32;
                 property.previous_value.improvement_exempt /= .32;
             }
-            
+
             // Parse timestamp from API
             property.sales_information.sales_date = parseInt(property.sales_information.sales_date.replace(/[^-\d]/g, ""), 0);
-            
+
             return property;
         }
         //,sync: function(method, collection, options) {
 	});
-    
+
     app.Collections.SearchResults = Backbone.Collection.extend({
         settings: {
-            apiHost: "http://api.phila.gov/opa/v1.1/"
+            apiHost: "http://api.phila.gov/ais/v1/"
             ,skip: 0
             ,limit: 30
         }
         ,initialize: function(models, options) {
-            this.method = options.method || "";
+            this.method = 'search';
             this.input = options.input || "";
             this.skip = this.settings.skip;
             this.limit = this.settings.limit;
         }
         ,url: function() {
-            return this.settings.apiHost + this.method + "/" + this.input + "/?format=json&limit=" + this.limit + "&skip=" + this.skip;
+            return this.settings.apiHost + this.method + "/" + this.input + "/?limit=" + this.limit + "&skip=" + this.skip + '&include_units&opa_only';
         }
         ,parse: function(response, options) {
-            this.moreAvailable = response.total > this.length + response.data.properties.length;
-            return response.data.properties;
+            this.moreAvailable = response.total_size > this.length + response.features.length;
+            return response.features;
         }
         /**
         * Override sync to return 404 if no records
@@ -93,7 +94,12 @@ window.Backbone = window.Backbone || {};
             var collection = this
                 ,oldOptions = _.clone(options);
             options.success = function(response, status, options) {
-                if(response.status === "error" || response.data.properties === undefined || ! response.data.properties.length) {
+                var features = _.filter(response.features, function (feature) {
+                  // ignore ais "parsed" results (aka addresses that have
+                  // been parsed but don't exist)
+                  return feature.match_type != 'parsed';
+                });
+                if(response.status === "error" || ! features.length) {
                     oldOptions.error({status: 404});
                 } else {
                     oldOptions.success(response, options);
@@ -102,7 +108,7 @@ window.Backbone = window.Backbone || {};
             Backbone.sync(method, collection, options);
         }
     });
-    
+
     /**
      * Home/Search View
      * Handles enhanced <select>, form submission
@@ -143,9 +149,9 @@ window.Backbone = window.Backbone || {};
             var field = $("#field").data("value")
                 ,inputNode = e.currentTarget.input
                 ,input = $.trim(inputNode.value);
-            
+
             input = this.sanitize(input, field);
-            
+
             if(input && field === "actnum") {
                 app.router.navigate("view/" + input, {trigger: true});
             } else if(input && field === "address") {
@@ -158,7 +164,7 @@ window.Backbone = window.Backbone || {};
             return typeof input === "string" ? input.replace(type === "actnum" ? /[^\d]/g : /[^\w\d\s-]/g, "") : "";
         }
     });
-    
+
     /**
      * Property View
      * Renders the property details and handles user calculations
@@ -203,10 +209,10 @@ window.Backbone = window.Backbone || {};
                 ,rate = 1.3998
                 ,taxableValue = Math.max(0, marketValue - exemptValue - homestead)
                 ,tax = Math.max(0, taxableValue * (rate / 100));
-            
+
             // Show taxable market value
             this.$("#taxable-value").text("$" + util.formatNumber(taxableValue));
-                
+
             // Show new tax
             this.$("#tax").text("$" + util.formatNumber(tax, true));
         }
@@ -219,7 +225,7 @@ window.Backbone = window.Backbone || {};
             }
         }
     });
-    
+
     /**
      * Search Results View
      * When multiple properties are found for the user's input, this renders a list
@@ -269,7 +275,7 @@ window.Backbone = window.Backbone || {};
             this.$(".more").toggle(this.collection.moreAvailable);
         }
     });
-    
+
     /**
      * Search Results Row View
      * The individual row in the list of multiple properties found in a search result
@@ -285,7 +291,7 @@ window.Backbone = window.Backbone || {};
             return this;
         }
     })
-    
+
     /**
      * Error View
      * Displayed when there is an ajax error
@@ -309,7 +315,7 @@ window.Backbone = window.Backbone || {};
             window.location.reload();
         }
     })
-    
+
     /**
      * Application Router
      */
@@ -356,7 +362,6 @@ window.Backbone = window.Backbone || {};
         ,view: function(input) {
             var self = this;
             input = decodeURIComponent(input);
-            //app.properties = new app.Collections.Properties(null, {actnum: actnum});
             app.property = new app.Models.Property({input: input});
             util.loading(true);
             app.property.fetch({
@@ -388,7 +393,11 @@ window.Backbone = window.Backbone || {};
                     util.loading(false);
                     if(collection.length === 1) {
                         // If we found 1 account number, view it
-                        self.navigate("view/" + collection.at(0).get("account_number"), {trigger: true, replace: true});
+                        var obj = collection.at(0),
+                            acct = obj.attributes.properties.opa_account_num;
+
+                        // self.navigate("view/" + collection.at(0).get("properties").get('opa_account_num'), {trigger: true, replace: true});
+                        self.navigate("view/" + acct, {trigger: true, replace: true});
                     } else {
                         // If we found multiple account numbers, get the addresses of each
                         //self.multiple(collection.pluck("TopicID"));
@@ -433,7 +442,7 @@ window.Backbone = window.Backbone || {};
             if(window.DEBUG) console.log("Google Analytics Error", error, url);
         }
     });
-    
+
     /**
      * Initiate application
      */
@@ -441,5 +450,5 @@ window.Backbone = window.Backbone || {};
         app.router = new app.Routers.AppRouter();
         Backbone.history.start();
     });
-    
+
 })(window, window.jQuery, window._, window.Backbone, window.AVI, window.util);

--- a/js/dictionary/en.js
+++ b/js/dictionary/en.js
@@ -57,22 +57,22 @@ window.dictionary = window.dictionary || {};
 
         // Disclaimers
         ,disclaimer_rates: "These tax rates are to be used for estimating purposes only and are not the proposed or final tax rates."
-        ,disclaimer_learn: "To learn more about AVI, please go to <a href=\"http://www.phila.gov/opa\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,disclaimer_learn: "To learn more about AVI, please go to <a href=\"http://property.phila.gov\" target=\"_blank\">property.phila.gov</a>"
         ,disclaimer_appeal: "The deadline to file a First Level Review for tax year 2014 has passed.  If you think your new assessed value does not reflect what it could sell for in the market, you may file an appeal to the BRT on or before October 7, 2013."
         ,disclaimer_sale_price: "The sale price displayed may reflect the sale of multiple properties, and is not necessarily the sole indicator of current market value."
         ,disclaimer_homestead_yes: "If approved for the Homestead Exemption, the amount is indicated under 'Abatement/Exempt Value'. If you already have an abatement or are enrolled in the Longtime Owner Occupants Program (LOOP), then you are ineligible to also have the Homestead Exemption."
-        ,disclaimer_homestead_no: "If you own and occupy your property as your primary residence, then you can apply for the Homestead Exemption. To apply, call 215‐686‐9200 or <a href='http://www.phila.gov/OPA/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>apply online</a>. If you already have an abatement or are enrolled in the Longtime Owner Occupants Program (LOOP), then you are ineligible to also have the Homestead Exemption."
+        ,disclaimer_homestead_no: "If you own and occupy your property as your primary residence, then you can apply for the Homestead Exemption. To apply, call 215‐686‐9200 or <a href='http://property.phila.gov/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>apply online</a>. If you already have an abatement or are enrolled in the Longtime Owner Occupants Program (LOOP), then you are ineligible to also have the Homestead Exemption."
 
         // Errors
         ,error: "Error"
         ,error_being_updated: "Data for this property is being updated. Please check back later."
         ,error_no_matches: "No matches found for <code>%s</code>."
         ,error_best_results: "For best results, try entering the account number of your property."
-        ,error_should_have_worked: "If you think this should have worked, you can try searching at <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,error_should_have_worked: "If you think this should have worked, you can try searching at <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
         ,error_database: "An error occurred while finding the property in the database. Please try again."
         ,error_verifying: "An error occurred while verifying the address. Please try again."
         ,error_generic: "An error occurred. Please try again."
-        ,error_addendum: "You can also try searching at <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,error_addendum: "You can also try searching at <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
 
         // Property Conditions
         ,cond_0: "Not Applicable"

--- a/js/dictionary/es.js
+++ b/js/dictionary/es.js
@@ -57,22 +57,22 @@ window.dictionary = window.dictionary || {};
 
         // Disclaimers
         ,disclaimer_rates: "Estas tasas impositivas deben utilizarse solo para fines estimativos y no son las tasas propuestas o finales."
-        ,disclaimer_learn: "Para conocer más acerca de AVI, visite <a href=\"http://www.phila.gov/opa\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,disclaimer_learn: "Para conocer más acerca de AVI, visite <a href=\"http://property.phila.gov\" target=\"_blank\">property.phila.gov</a>"
         ,disclaimer_appeal: " "
         ,disclaimer_sale_price: "El precio de venta presentado puede reflejar la venta de varias propiedades y no es necesariamente el único indicador del valor actual de mercado."
         ,disclaimer_homestead_yes: "Si usted es aprobado para la Exención Homestead, entonces la cantidad se encuentra en 'Reducción / Valor Exento'. Usted no es elegible para que la Exención Homestead si ya tienes una reducción o está inscrito en el Programa El veterano Ocupantes Propietario (LOOP)."
-        ,disclaimer_homestead_no: "Si usted es dueño y ocupa su propiedad como su residencia principal, entonces usted puede solicitar la exención Homestead . <a href='http://www.phila.gov/OPA/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>Aplicar en línea</a> o llame al 215-686-9200 para solicitar por teléfono. Usted no tiene derecho a tener también la exención Homestead si ya tienes una reducción o está inscrito en el Programa El veterano Ocupantes Propietario (LOOP)."
+        ,disclaimer_homestead_no: "Si usted es dueño y ocupa su propiedad como su residencia principal, entonces usted puede solicitar la exención Homestead . <a href='http://property.phila.gov/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>Aplicar en línea</a> o llame al 215-686-9200 para solicitar por teléfono. Usted no tiene derecho a tener también la exención Homestead si ya tienes una reducción o está inscrito en el Programa El veterano Ocupantes Propietario (LOOP)."
 
         // Errors
         ,error: "Error"
         ,error_being_updated: "Los datos de esta propiedad se están actualizando. Vuelva a intentarlo más tarde."
         ,error_no_matches: "No se encontró ninguna coincidencia para <code>%s</code>."
         ,error_best_results: "Para obtener mejores resultados, intente ingresar el número de cuenta de su propiedad."
-        ,error_should_have_worked: "Si cree que esto debiera haber funcionado, puede intentar la búsqueda en <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,error_should_have_worked: "Si cree que esto debiera haber funcionado, puede intentar la búsqueda en <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
         ,error_database: "Se produjo un error al buscar la propiedad en la base de datos. Vuelva a intentarlo."
         ,error_verifying: "Se produjo un error al verificar la dirección. Vuelva a intentarlo."
         ,error_generic: "Se produjo un error. Vuelva a intentarlo."
-        ,error_addendum: "También puede intentar la búsqueda en <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,error_addendum: "También puede intentar la búsqueda en <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
 
         // Property Conditions
         ,cond_0: "No corresponde"

--- a/js/dictionary/ko.js
+++ b/js/dictionary/ko.js
@@ -57,22 +57,22 @@ window.dictionary = window.dictionary || {};
 
         // Disclaimers
         ,disclaimer_rates: "이 세율은 추산을 위해서만 사용하는 세율로, 제안된 또는 최종 세율이 아닙니다."
-        ,disclaimer_learn: "AVI에 관한 자세한 정보가 필요하신 경우, <a href=\"http://www.phila.gov/opa\" target=\"_blank\">www.phila.gov/opa</a>를 방문하십시오."
+        ,disclaimer_learn: "AVI에 관한 자세한 정보가 필요하신 경우, <a href=\"http://property.phila.gov\" target=\"_blank\">property.phila.gov</a>를 방문하십시오."
         ,disclaimer_appeal: " "
         ,disclaimer_sale_price: "표시된 매매가가 여러 부동산의 매매를 포함할 수 있으며, 반드시 현재 시장 가치의 유일한 지표가 아닙니다."
         ,disclaimer_homestead_yes: "당신이 농가 면제 승인을받은 경우, 양이 '감면 / 면제 값' 에서 찾을 수 있습니다. 이미 감소 가 있거나오랜 소유자 거주자 프로그램 (LOOP) 에 등록 하는 경우에는 농가 면제 를 가질 자격이 없습니다."
-        ,disclaimer_homestead_no: "당신이 소유하고 주 거주지로 귀하의 재산 을 점유 하는 경우는 농가 면제 를 신청할 수 있습니다. <a href='http://www.phila.gov/OPA/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>온라인</a> 를 적용하거나 전화로 신청 할 215-686-9200 를 호출합니다. 이미 감소 가 있거나오랜 소유자 거주자 프로그램 ( LOOP ) 에 등록 하는 경우 도 농가 면제 를 가질 자격이 없습니다."
+        ,disclaimer_homestead_no: "당신이 소유하고 주 거주지로 귀하의 재산 을 점유 하는 경우는 농가 면제 를 신청할 수 있습니다. <a href='http://property.phila.gov/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>온라인</a> 를 적용하거나 전화로 신청 할 215-686-9200 를 호출합니다. 이미 감소 가 있거나오랜 소유자 거주자 프로그램 ( LOOP ) 에 등록 하는 경우 도 농가 면제 를 가질 자격이 없습니다."
 
         // Errors
         ,error: "오류"
         ,error_being_updated: "이 부동산의 데이터가 업데이트되고 있습니다. 나중에 다시 확인해 주십시오."
         ,error_no_matches: "<code>%s</code> 와(과) 일치하는 결과를 찾을 수 없습니다."
         ,error_best_results: "최선의 결과를 위해, 부동산의 계정 번호를 입력해 보십시오."
-        ,error_should_have_worked: "이 검색에 문제가 없었다고 생각하는 경우, <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a>에서 검색해 볼 수 있습니다."
+        ,error_should_have_worked: "이 검색에 문제가 없었다고 생각하는 경우, <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>에서 검색해 볼 수 있습니다."
         ,error_database: "데이터베이스에서 부동산을 검색하는 동안 오류가 발생했습니다. 다시 시도해 보십시오."
         ,error_verifying: "주소를 확인하는 동안 오류가 발생했습니다. 다시 시도해 보십시오."
         ,error_generic: "오류가 발생했습니다. 다시 시도해 보십시오."
-        ,error_addendum: "또한 <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a>에서 검색해 볼 수 있습니다."
+        ,error_addendum: "또한 <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>에서 검색해 볼 수 있습니다."
 
         // Property Conditions
         ,cond_0: "해당 사항 없음"

--- a/js/dictionary/ru.js
+++ b/js/dictionary/ru.js
@@ -57,22 +57,22 @@ window.dictionary = window.dictionary || {};
 
         // Disclaimers
         ,disclaimer_rates: "Эти налоговые ставки следует использовать только в целях расчета; они не являются предлагаемыми или окончательными налоговыми ставками."
-        ,disclaimer_learn: "Чтобы больше узнать об AVI, зайдите на веб-сайт <a href=\"http://www.phila.gov/opa\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,disclaimer_learn: "Чтобы больше узнать об AVI, зайдите на веб-сайт <a href=\"http://property.phila.gov\" target=\"_blank\">property.phila.gov</a>"
         ,disclaimer_appeal: " "
         ,disclaimer_sale_price: "Показанная цена продажи может отражать сумму продажу нескольких объектов недвижимости и не обязательно является единственным показателем текущей рыночной стоимости."
         ,disclaimer_homestead_yes: "Если вы одобрен для Усадьба исключения, токоличество находится в разделе 'борьбы с загрязнением воздуха / Освобожденный стоимости'. Вы не имеете права иметь приусадебный освобождение, если у вас уже есть борьбы с выбросами или зачислены в долгосрочном Владелец Оккупанты программы (цикла)"
-        ,disclaimer_homestead_no: "Если у вас есть и занимают свое имущество в качестве основного места жительства, то вы можете подать заявку на Ферме исключения. <a href='http://www.phila.gov/OPA/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>Нанесите на форуме</a> или позвоните по телефону 215-686-9200, чтобы применить по телефону . Вы не имеете права также имеют приусадебный освобождение, если у вас уже есть борьбы с выбросами или зачислены в долгосрочном Владелец Оккупанты программы (цикла)."
+        ,disclaimer_homestead_no: "Если у вас есть и занимают свое имущество в качестве основного места жительства, то вы можете подать заявку на Ферме исключения. <a href='http://property.phila.gov/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>Нанесите на форуме</a> или позвоните по телефону 215-686-9200, чтобы применить по телефону . Вы не имеете права также имеют приусадебный освобождение, если у вас уже есть борьбы с выбросами или зачислены в долгосрочном Владелец Оккупанты программы (цикла)."
 
         // Errors
         ,error: "Ошибка"
         ,error_being_updated: "Данные по этому объекту недвижимости обновляются. Пожалуйста, проверьте позже."
         ,error_no_matches: "Не найдено соответствий для <code>%s</code>."
         ,error_best_results: "Для получения наиболее точных результатов попробуйте ввести учетный номер вашего объекта недвижимости."
-        ,error_should_have_worked: "Если вы считаете, что это должно было сработать, вы можете попробовать поискать на веб-сайте <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,error_should_have_worked: "Если вы считаете, что это должно было сработать, вы можете попробовать поискать на веб-сайте <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
         ,error_database: "Произошла ошибка при поиске объекта недвижимости в базе данных. Пожалуйста, повторите попытку. "
         ,error_verifying: "Произошла ошибка при проверке адреса. Пожалуйста, повторите попытку."
         ,error_generic: "Произошла ошибка. Пожалуйста, повторите попытку."
-        ,error_addendum: "Также вы можете попробовать осуществить поиск на веб-сайте <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,error_addendum: "Также вы можете попробовать осуществить поиск на веб-сайте <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
 
         // Property Conditions
         ,cond_0: "Неприменимо"

--- a/js/dictionary/vi.js
+++ b/js/dictionary/vi.js
@@ -57,22 +57,22 @@ window.dictionary = window.dictionary || {};
 
         // Disclaimers
         ,disclaimer_rates: "Các thuế suất này được sử dụng chỉ cho các mục đích ước tính và không phải là các thuế suất được đề xuất hoặc cuối cùng."
-        ,disclaimer_learn: "Để tìm hiểu thêm về AVI, vui lòng ghé thăm <a href=\"http://www.phila.gov/opa\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,disclaimer_learn: "Để tìm hiểu thêm về AVI, vui lòng ghé thăm <a href=\"http://property.phila.gov\" target=\"_blank\">property.phila.gov</a>"
         ,disclaimer_appeal: " "
         ,disclaimer_sale_price: "Giá bán được hiển thị có thể phản ánh việc bán nhiều bất động sản, và không nhất thiết là chỉ số duy nhất của giá trị thị trường hiện tại."
         ,disclaimer_homestead_yes: "Nếu được chấp thuận cho Exemption Homestead, sau đó số tiền được tìm thấy dưới 'loại giảm / Giá trị được miễn thuế'. Bạn không đủ điều kiện để có miễn Homestead nếu bạn đã có một giảm hoặc đang theo học trong Chương trình Người cư ngụ lâu năm chủ (LOOP)."
-        ,disclaimer_homestead_no: "Nếu bạn sở hữu và chiếm tài sản của bạn là nơi ở chính của bạn , sau đó bạn có thể áp dụng cho những Miễn Homestead. <a href='http://www.phila.gov/OPA/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>Áp dụng</a> trực tuyến hoặc gọi 215-686-9200 để đơn bằng điện thoại. Bạn không đủ điều kiện cũng có Exemption Homestead nếu bạn đã có một giảm hoặc đang theo học trong Chương trình Người cư ngụ lâu năm chủ (LOOP)."
+        ,disclaimer_homestead_no: "Nếu bạn sở hữu và chiếm tài sản của bạn là nơi ở chính của bạn , sau đó bạn có thể áp dụng cho những Miễn Homestead. <a href='http://property.phila.gov/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>Áp dụng</a> trực tuyến hoặc gọi 215-686-9200 để đơn bằng điện thoại. Bạn không đủ điều kiện cũng có Exemption Homestead nếu bạn đã có một giảm hoặc đang theo học trong Chương trình Người cư ngụ lâu năm chủ (LOOP)."
 
         // Errors
         ,error: "Lỗi"
         ,error_being_updated: "Dữ liệu cho bất động sản này đang được cập nhật. Xin vui lòng kiểm tra lại sau."
         ,error_no_matches: "Không có kết quả phù hợp được tìm thấy cho <code>%s</code>."
         ,error_best_results: "Để có các kết quả tốt nhất, hãy thử nhập số tài khoản của bất động sản của quý vị."
-        ,error_should_have_worked: "Nếu nghĩ rằng điều này có hiệu quả, quý vị có thể thử tìm kiếm tại <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,error_should_have_worked: "Nếu nghĩ rằng điều này có hiệu quả, quý vị có thể thử tìm kiếm tại <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
         ,error_database: "Lỗi xảy ra trong khi tìm kiếm bất động sản trong cơ sở dữ liệu. Xin vui lòng thử lại."
         ,error_verifying: "Lỗi xảy ra trong khi xác nhận địa chỉ. Xin vui lòng thử lại."
         ,error_generic: "Có lỗi đã xảy ra. Xin vui lòng thử lại."
-        ,error_addendum: "Quý vị cũng có thể thử tìm kiếm tại <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,error_addendum: "Quý vị cũng có thể thử tìm kiếm tại <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
 
         // Property Conditions
         ,cond_0: "Không Áp Dụng"

--- a/js/dictionary/zh.js
+++ b/js/dictionary/zh.js
@@ -57,22 +57,22 @@ window.dictionary = window.dictionary || {};
 
         // Disclaimers
         ,disclaimer_rates: "該等稅率僅用於估算目的，且並非擬定或最終稅率。"
-        ,disclaimer_learn: "欲知 AVI 詳情，請前往 <a href=\"http://www.phila.gov/opa\" target=\"_blank\">www.phila.gov/opa</a>"
+        ,disclaimer_learn: "欲知 AVI 詳情，請前往 <a href=\"http://property.phila.gov\" target=\"_blank\">property.phila.gov</a>"
         ,disclaimer_appeal: " "
         ,disclaimer_sale_price: "所顯示的銷售價格可反映多個物業的銷售，且不一定為當前市值的唯一指標。"
         ,disclaimer_homestead_yes: "如果您被批准的宅基地豁免，则量下的“减排/豁免值”找到。你是没有资格拥有宅基地豁免，如果你已经有一个减排或正在就读于隆泰业主居住者计划（LOOP）。"
-        ,disclaimer_homestead_no: "如果你拥有和占据你的财产作为您的主要居住地，那么你可以申请宅基地豁免。 <a href='http://www.phila.gov/OPA/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>在线申请</a>或拨打215-686-9200电话申请。你是没有资格也有宅基地豁免，如果你已经有一个减排或正在就读于隆泰业主居住者计划（LOOP）。"
+        ,disclaimer_homestead_no: "如果你拥有和占据你的财产作为您的主要居住地，那么你可以申请宅基地豁免。 <a href='http://property.phila.gov/AbatementsExemptions/Pages/Homestead.aspx' target='_blank'>在线申请</a>或拨打215-686-9200电话申请。你是没有资格也有宅基地豁免，如果你已经有一个减排或正在就读于隆泰业主居住者计划（LOOP）。"
 
         // Errors
         ,error: "錯誤"
         ,error_being_updated: "此物業的數據已被更新。請稍後檢查。"
         ,error_no_matches: "未找到 <code>%s</code>的匹配項目。"
         ,error_best_results: "如欲得到最佳結果，請嘗試輸入您物業的賬號。"
-        ,error_should_have_worked: "如果您認為此法應當奏效，您可嘗試在 <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a> 上進行搜尋"
+        ,error_should_have_worked: "如果您認為此法應當奏效，您可嘗試在 <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a> 上進行搜尋"
         ,error_database: "在資料庫中尋找物業時發生一個錯誤。請重試。"
         ,error_verifying: "在驗證地址時發生一個錯誤。請重試。"
         ,error_generic: "發生一個錯誤。請重試。"
-        ,error_addendum: "您還可嘗試在 <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">www.phila.gov/opa</a> 上進行搜尋"
+        ,error_addendum: "您還可嘗試在 <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a> 上進行搜尋"
 
         // Property Conditions
         ,cond_0: "不適用"


### PR DESCRIPTION
This branch uses AIS for the initial call to standardize the search address and bring back the OPA account number. After that, it uses the OPA API to get account details. This should reduce the number of requests this app makes to ULRS by about half.