### PR TITLE
Use Carto instead of OPA API

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,17 +123,16 @@
                         <h3><%= D("previous_value") %></h3>
                     </div>
                     <div class="widget-content">
+                        <% var prev = data.assessmentHistory[1]; %>
                         <ul class="nav nav-list">
                             <li class="nav-header"><%= D("market_value") %></li>
-                            <li><span class="marketvalue">$<%= util.formatNumber(data.property.previous_value.market_value, false) %></span></li>
+                            <li><span class="marketvalue">$<%= util.formatNumber(prev.market_value, false) %></span></li>
                             <li class="nav-header"><%= D("land_value") %></li>
-                            <li>$<%= util.formatNumber(data.property.previous_value.land_taxable + data.property.previous_value.land_exempt, false) %></li>
+                            <li>$<%= util.formatNumber(prev.taxable_land + prev.exempt_land, false) %></li>
                             <li class="nav-header"><%= D("improvement_value") %></li>
-                            <li>$<%= util.formatNumber(data.property.previous_value.improvement_taxable + data.property.previous_value.improvement_exempt, false) %></li>
+                            <li>$<%= util.formatNumber(prev.taxable_building + prev.exempt_building, false) %></li>
                             <li class="nav-header"><%= D("exempt_value") %></li>
-                            <li>$<%= util.formatNumber(data.property.previous_value.land_exempt + data.property.previous_value.improvement_exempt, false) %></li>
-                            <li class="nav-header"><%= D("tax_2013").replace("2013", data.property.previous_value.certification_year) %></li>
-                            <li>$<%= util.formatNumber(data.property.previous_value.taxes, false) %></li>
+                            <li>$<%= util.formatNumber(prev.exempt_land + prev.exempt_building, false) %></li>
                         </ul>
                     </div>
                 </div>
@@ -144,16 +143,17 @@
                         <h3><%= D("new_value") %></h3>
                     </div>
                     <div class="widget-content">
-                        <% if(data.property.new_value.market_value >= 0) { %>
+                        <% var next = data.assessmentHistory[0]; %>
+                        <% if(next.market_value >= 0) { %>
                         <ul class="nav nav-list">
                             <li class="nav-header"><%= D("market_value") %></li>
-                            <li><span class="marketvalue">$<%= util.formatNumber(data.property.new_value.market_value, false) %></span></li>
+                            <li><span class="marketvalue">$<%= util.formatNumber(next.market_value, false) %></span></li>
                             <li class="nav-header"><%= D("land_value") %></li>
-                            <li>$<%= util.formatNumber(data.property.new_value.land_taxable + data.property.new_value.land_exempt, false) %></li>
+                            <li>$<%= util.formatNumber(next.taxable_land + next.exempt_land, false) %></li>
                             <li class="nav-header"><%= D("improvement_value") %></li>
-                            <li>$<%= util.formatNumber(data.property.new_value.improvement_taxable + data.property.new_value.improvement_exempt, false) %></li>
+                            <li>$<%= util.formatNumber(next.taxable_building + next.exempt_building, false) %></li>
                             <li class="nav-header"><%= D("exempt_value") %></li>
-                            <li>$<%= util.formatNumber(data.property.new_value.land_exempt + data.property.new_value.improvement_exempt, false) %></li>
+                            <li>$<%= util.formatNumber(next.exempt_land + next.exempt_building, false) %></li>
                         </ul>
                         <% } else { %>
                             <%= D("error_being_updated") %>
@@ -165,7 +165,7 @@
             <div class="span4">
                 <div class="widget">
                     <div class="widget-header">
-                        <h3><%= D("estimate_2014_tax").replace("2014", data.property.new_value.certification_year) %></h3>
+                        <h3><%= D("estimate_2014_tax").replace("2014", next.year) %></h3>
                     </div>
                     <div class="widget-content">
                         <ul class="nav nav-list">
@@ -181,7 +181,7 @@
                             <li><span id="taxable-value"></span></li>
                             <li class="nav-header"><%= D("tax_rate") %></li>
                             <li>1.3998%</li>
-                            <li class="nav-header"><%= D("estimated_2014_tax").replace("2014", data.property.new_value.certification_year) %></li>
+                            <li class="nav-header"><%= D("estimated_2014_tax").replace("2014", next.year) %></li>
                             <li>
                                 <div class="above"><button class="btn btn-large"><%= D("estimate_button") %></button></div>
                                 <div class="beneath"><span id="tax"></span></div>

--- a/index.html
+++ b/index.html
@@ -110,11 +110,11 @@
     <!-- Property View Template -->
     <script type="text/template" id="tmpl-property">
         <h1>
-            <%= data.property.full_address %>
+            <%= data.property.location %>
             <% if($.trim(data.property.unit)) { %>
                 <span class="unit"><%= D("unit") %>: <%= data.property.unit %></span>
             <% } %>
-            <small><%= D("account") %> <%= data.property.account_number %></small>
+            <small><%= D("account") %> <%= data.property.parcel_number %></small>
         </h1>
         <div class="row">
             <div class="span4">
@@ -161,7 +161,7 @@
                     </div>
                 </div>
             </div>
-            <% if(data.property.new_value.market_value >= 0) { %>
+            <% if(next.market_value >= 0) { %>
             <div class="span4">
                 <div class="widget">
                     <div class="widget-header">
@@ -169,8 +169,8 @@
                     </div>
                     <div class="widget-content">
                         <ul class="nav nav-list">
-                            <li class="nav-header<%= data.property.characteristics.homestead ? ' hidden' : '' %>"><%= D("homestead_exemption") %></li>
-                            <li class="<%= data.property.characteristics.homestead ? ' hidden' : '' %>">
+                            <li class="nav-header<%= data.property.homestead_exemption ? ' hidden' : '' %>"><%= D("homestead_exemption") %></li>
+                            <li class="<%= data.property.homestead_exemption ? ' hidden' : '' %>">
                                 <select name="homestead" id="homestead" class="input-medium">
                                     <option value="0"><%= D("select_option") %>...</option>
                                     <option value="0"><%= D("no_homestead") %></option>
@@ -202,32 +202,32 @@
                         <ul class="nav nav-list">
                             <li class="nav-header"><%= D("owners") %></li>
                             <li>
-                                <% _.each(data.property.ownership.owners, function(owner) { %>
-                                    <%= owner %><br>
-                                <% }); %>
+                                <%= data.property.owner_1 %>
+                                <br>
+                                <%= data.property.owner_2 %>
                             </li>
                             <li class="nav-header"><%= D("zip") %></li>
-                            <li><%= data.property.zip %>
+                            <li><%= data.property.zip_code %>
                             <li class="nav-header"><%= D("sale_date") %></li>
-                            <li><%= util.friendlyDate(data.property.sales_information.sales_date) %></li>
+                            <li><%= util.friendlyDate(data.property.sale_date) %></li>
                             <li class="nav-header"><%= D("sale_price") %>*</li>
-                            <li>$<%= util.formatNumber(data.property.sales_information.sales_price || 0) %></li>
+                            <li>$<%= util.formatNumber(data.property.sale_price || 0) %></li>
                             <li class="nav-header"><%= D("homestead") %></li>
-                            <li><%= data.property.characteristics.homestead ? D("yes") : D("no") %>**</li>
+                            <li><%= data.property.homestead_exemption ? D("yes") : D("no") %>**</li>
                         </ul>
                     </div>
                     <div class="span5">
                         <ul class="nav nav-list">
                             <li class="nav-header"><%= D("land_area") %></li>
-                            <li><%= util.formatNumber(data.property.characteristics.land_area || 0) %> SqFt</li>
+                            <li><%= util.formatNumber(data.property.total_area || 0) %> SqFt</li>
                             <li class="nav-header"><%= D("improvement_area") %></li>
-                            <li><%= util.formatNumber(data.property.characteristics.improvement_area || 0) %> SqFt</li>
+                            <li><%= util.formatNumber(data.property.total_livable_area || 0) %> SqFt</li>
                             <li class="nav-header"><%= D("beginning_point") %></li>
-                            <li><%= data.property.characteristics.beginning_point %></li>
+                            <li><%= data.property.beginning_point %></li>
                             <li class="nav-header"><%= D("ext_condition") %></li>
-                            <li><%= window.D("cond_" + (data.property.characteristics.exterior_condition ? data.property.characteristics.exterior_condition : "0")) %></li>
+                            <li><%= window.D("cond_" + (data.property.exterior_condition ? data.property.exterior_condition : "0")) %></li>
                             <li class="nav-header"><%= D("zoning") %></li>
-                            <li><%= data.property.characteristics.zoning %></li>
+                            <li><%= data.property.zoning %></li>
                         </ul>
                     </div>
                 </div>
@@ -235,7 +235,7 @@
         </div>
         <p><%= D("disclaimer_learn") %></p>
         <p>* <%= D("disclaimer_sale_price") %></p>
-        <p>** <%= data.property.characteristics.homestead ? D("disclaimer_homestead_yes") : D("disclaimer_homestead_no")%></p>
+        <p>** <%= data.property.homestead_exemption ? D("disclaimer_homestead_yes") : D("disclaimer_homestead_no")%></p>
 
         <a href="#" class="btn btn-large"><i class="icon-chevron-left"></i> <%= D("new_search_button") %></a>
 


### PR DESCRIPTION
@tswanson this is ready for review. The two things I'm unsure of:

1. Is the tax rate of `1.3998%` accurate? I don't remember updating this in the past. We'd need to update it both in `index.html` and `app.js`.
2. I vaguely recall that with the OPA API, there was a certain point every year, around the time the new assessments were released, when the old OPA API showed a `proposed_value` (with a market value, exempt land/building, etc.). This app was wired to use that if it was available; otherwise it would use the most recent record in the valuation history. With this PR, it always uses the most recent record in the valuation history. Is this okay? I think we may need to confirm with Tom D.