### PR TITLE
Disable search and add redirect banner

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -56,3 +56,11 @@ body { margin-bottom: 20px; }
 
 /* Properties list margin */
 #list { margin-bottom: 0px; }
+
+.deprecation-warning {
+  background: rgb(255, 243, 160);
+  padding: 1em;
+  text-align: center;
+  margin-bottom: 1em;
+  margin-top: -1em;
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -58,9 +58,7 @@ body { margin-bottom: 20px; }
 #list { margin-bottom: 0px; }
 
 .deprecation-warning {
-  background: rgb(255, 243, 160);
-  padding: 1em;
-  text-align: center;
-  margin-bottom: 1em;
-  margin-top: -1em;
+  font-size: 200%;
+  font-weight: bold;
+  padding: 25px;
 }

--- a/index.html
+++ b/index.html
@@ -67,6 +67,15 @@
 	</div>
 
     <!-- Main Content Container -->
+    <div class="deprecation-warning">
+      <div class="container">
+        <h3>
+          The Actual Value Initiative has ended and this application is no longer in service.
+          To estimate real estate taxes for a property, please visit
+          <a href="//property.phila.gov">property.phila.gov</a>.
+        </h3>
+      </div>
+    </div>
     <div class="container" id="main"></div>
 
     <!-- AJAX loading spinner -->
@@ -83,7 +92,7 @@
         <form>
             <div class="input-prepend">
                 <div class="btn-group" id="field" data-value="<%= data.field || "address"%>">
-                    <button class="btn dropdown-toggle" data-toggle="dropdown" type="button">
+                    <button class="btn dropdown-toggle disabled" data-toggle="dropdown" type="button">
                         <span class="dropdown-value"><%= data.field === "actnum" ? D("account") : D("address") %></span>
                         <span class="caret"></span>
                     </button>
@@ -92,9 +101,9 @@
                         <li><a href="" data-value="actnum" data-placeholder="<%= D("account_example") %>"><%= D("account") %></a></li>
                     </ul>
                 </div>
-                <input type="text" name="input" id="input" value="<%= data.input || "" %>" placeholder="<%= data.field === "actnum" ? D("account_example") : D("address_example") %>" autofocus>
+                <input disabled type="text" name="input" id="input" value="<%= data.input || "" %>" placeholder="<%= data.field === "actnum" ? D("account_example") : D("address_example") %>" autofocus>
             </div>
-            <button class="btn btn-large btn-primary" type="submit"><i class="icon-search icon-white"></i> <%= D("search_button") %></button>
+            <button disabled class="btn btn-large btn-primary" type="submit"><i class="icon-search icon-white"></i> <%= D("search_button") %></button>
         </form>
 
         <ul id="language" class="nav nav-pills pull-right">

--- a/index.html
+++ b/index.html
@@ -67,15 +67,6 @@
 	</div>
 
     <!-- Main Content Container -->
-    <div class="deprecation-warning">
-      <div class="container">
-        <h3>
-          The Actual Value Initiative has ended and this application is no longer in service.
-          To estimate real estate taxes for a property, please visit
-          <a href="//property.phila.gov">property.phila.gov</a>.
-        </h3>
-      </div>
-    </div>
     <div class="container" id="main"></div>
 
     <!-- AJAX loading spinner -->
@@ -89,7 +80,11 @@
         <% if(data.noresults) { %>
         <div class="alert alert-error"><%= D("error_no_matches", data.input) %> <%= data.field !== "actnum" ? D("error_best_results") : "" %><%= D("error_should_have_worked", [data.input, data.input]) %></div>
         <% } %>
-        <form>
+        <div class="alert alert-error deprecation-warning">
+          To estimate your Real Estate Tax, please visit
+          <a href="//property.phila.gov">property.phila.gov</a>.
+        </div>
+        <!--<form>
             <div class="input-prepend">
                 <div class="btn-group" id="field" data-value="<%= data.field || "address"%>">
                     <button class="btn dropdown-toggle disabled" data-toggle="dropdown" type="button">
@@ -104,7 +99,7 @@
                 <input disabled type="text" name="input" id="input" value="<%= data.input || "" %>" placeholder="<%= data.field === "actnum" ? D("account_example") : D("address_example") %>" autofocus>
             </div>
             <button disabled class="btn btn-large btn-primary" type="submit"><i class="icon-search icon-white"></i> <%= D("search_button") %></button>
-        </form>
+        </form>-->
 
         <ul id="language" class="nav nav-pills pull-right">
             <li<% if(AVI.language === "en"){ %> class="active"<%}%>><a href="" data-value="en">English</a></li>

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
         <h3><%= D("app_desc1") %></h3>
         <p><%= D("app_desc2") %></p>
         <% if(data.noresults) { %>
-        <div class="alert alert-error"><%= D("error_no_matches", data.input) %> <%= data.field !== "actnum" ? D("error_best_results") : "" %><%= D("error_should_have_worked") %></div>
+        <div class="alert alert-error"><%= D("error_no_matches", data.input) %> <%= data.field !== "actnum" ? D("error_best_results") : "" %><%= D("error_should_have_worked", [data.input, data.input]) %></div>
         <% } %>
         <form>
             <div class="input-prepend">
@@ -177,6 +177,10 @@
                         <h3><%= D("estimate_2014_tax").replace("2014", next.year) %></h3>
                     </div>
                     <div class="widget-content">
+                        <div class="alert alert-block">
+                            <h4>Remember!</h4>
+                            To estimate <strong>2019</strong> real estate taxes for <code><%= $.trim(data.property.location) %></code>, please go to <a href="//property.phila.gov?a=<%= encodeURIComponent($.trim(data.property.location)) %>" target="_blank">property.phila.gov</a>
+                        </div>
                         <ul class="nav nav-list">
                             <li class="nav-header<%= data.property.homestead_exemption ? ' hidden' : '' %>"><%= D("homestead_exemption") %></li>
                             <li class="<%= data.property.homestead_exemption ? ' hidden' : '' %>">

--- a/js/app.js
+++ b/js/app.js
@@ -325,8 +325,8 @@ window.Backbone = window.Backbone || {};
     app.Routers.AppRouter = Backbone.Router.extend({
         routes: {
             "": "home"
-            ,"view/:input": "view"
-            ,"search/:input": "search"
+            // ,"view/:input": "view"
+            // ,"search/:input": "search"
             ,"*path": "home"
         }
         /**

--- a/js/dictionary/en.js
+++ b/js/dictionary/en.js
@@ -68,7 +68,7 @@ window.dictionary = window.dictionary || {};
         ,error_being_updated: "Data for this property is being updated. Please check back later."
         ,error_no_matches: "No matches found for <code>%s</code>."
         ,error_best_results: "For best results, try entering the account number of your property."
-        ,error_should_have_worked: "If you think this should have worked, you can try searching at <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
+        ,error_should_have_worked: " If you think this should have worked, you can try searching at <a href=\"http://property.phila.gov/\" target=\"_blank\">property.phila.gov</a>"
         ,error_database: "An error occurred while finding the property in the database. Please try again."
         ,error_verifying: "An error occurred while verifying the address. Please try again."
         ,error_generic: "An error occurred. Please try again."

--- a/js/dictionary/es.js
+++ b/js/dictionary/es.js
@@ -68,7 +68,7 @@ window.dictionary = window.dictionary || {};
         ,error_being_updated: "Los datos de esta propiedad se están actualizando. Vuelva a intentarlo más tarde."
         ,error_no_matches: "No se encontró ninguna coincidencia para <code>%s</code>."
         ,error_best_results: "Para obtener mejores resultados, intente ingresar el número de cuenta de su propiedad."
-        ,error_should_have_worked: "Si cree que esto debiera haber funcionado, puede intentar la búsqueda en <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
+        ,error_should_have_worked: "Si cree que esto debiera haber funcionado, puede intentar la búsqueda en <a href=\"http://property.phila.gov/\" target=\"_blank\">http://property.phila.gov/</a>"
         ,error_database: "Se produjo un error al buscar la propiedad en la base de datos. Vuelva a intentarlo."
         ,error_verifying: "Se produjo un error al verificar la dirección. Vuelva a intentarlo."
         ,error_generic: "Se produjo un error. Vuelva a intentarlo."

--- a/js/dictionary/ko.js
+++ b/js/dictionary/ko.js
@@ -68,7 +68,7 @@ window.dictionary = window.dictionary || {};
         ,error_being_updated: "이 부동산의 데이터가 업데이트되고 있습니다. 나중에 다시 확인해 주십시오."
         ,error_no_matches: "<code>%s</code> 와(과) 일치하는 결과를 찾을 수 없습니다."
         ,error_best_results: "최선의 결과를 위해, 부동산의 계정 번호를 입력해 보십시오."
-        ,error_should_have_worked: "이 검색에 문제가 없었다고 생각하는 경우, <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>에서 검색해 볼 수 있습니다."
+        ,error_should_have_worked: "이 검색에 문제가 없었다고 생각하는 경우, <a href=\"http://property.phila.gov/\" target=\"_blank\">http://property.phila.gov/</a>에서 검색해 볼 수 있습니다."
         ,error_database: "데이터베이스에서 부동산을 검색하는 동안 오류가 발생했습니다. 다시 시도해 보십시오."
         ,error_verifying: "주소를 확인하는 동안 오류가 발생했습니다. 다시 시도해 보십시오."
         ,error_generic: "오류가 발생했습니다. 다시 시도해 보십시오."

--- a/js/dictionary/ru.js
+++ b/js/dictionary/ru.js
@@ -68,7 +68,7 @@ window.dictionary = window.dictionary || {};
         ,error_being_updated: "Данные по этому объекту недвижимости обновляются. Пожалуйста, проверьте позже."
         ,error_no_matches: "Не найдено соответствий для <code>%s</code>."
         ,error_best_results: "Для получения наиболее точных результатов попробуйте ввести учетный номер вашего объекта недвижимости."
-        ,error_should_have_worked: "Если вы считаете, что это должно было сработать, вы можете попробовать поискать на веб-сайте <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
+        ,error_should_have_worked: "Если вы считаете, что это должно было сработать, вы можете попробовать поискать на веб-сайте <a href=\"http://property.phila.gov/\" target=\"_blank\">http://property.phila.gov/</a>"
         ,error_database: "Произошла ошибка при поиске объекта недвижимости в базе данных. Пожалуйста, повторите попытку. "
         ,error_verifying: "Произошла ошибка при проверке адреса. Пожалуйста, повторите попытку."
         ,error_generic: "Произошла ошибка. Пожалуйста, повторите попытку."

--- a/js/dictionary/vi.js
+++ b/js/dictionary/vi.js
@@ -68,7 +68,7 @@ window.dictionary = window.dictionary || {};
         ,error_being_updated: "Dữ liệu cho bất động sản này đang được cập nhật. Xin vui lòng kiểm tra lại sau."
         ,error_no_matches: "Không có kết quả phù hợp được tìm thấy cho <code>%s</code>."
         ,error_best_results: "Để có các kết quả tốt nhất, hãy thử nhập số tài khoản của bất động sản của quý vị."
-        ,error_should_have_worked: "Nếu nghĩ rằng điều này có hiệu quả, quý vị có thể thử tìm kiếm tại <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a>"
+        ,error_should_have_worked: "Nếu nghĩ rằng điều này có hiệu quả, quý vị có thể thử tìm kiếm tại <a href=\"http://property.phila.gov/\" target=\"_blank\">http://property.phila.gov/</a>"
         ,error_database: "Lỗi xảy ra trong khi tìm kiếm bất động sản trong cơ sở dữ liệu. Xin vui lòng thử lại."
         ,error_verifying: "Lỗi xảy ra trong khi xác nhận địa chỉ. Xin vui lòng thử lại."
         ,error_generic: "Có lỗi đã xảy ra. Xin vui lòng thử lại."

--- a/js/dictionary/zh.js
+++ b/js/dictionary/zh.js
@@ -68,7 +68,7 @@ window.dictionary = window.dictionary || {};
         ,error_being_updated: "此物業的數據已被更新。請稍後檢查。"
         ,error_no_matches: "未找到 <code>%s</code>的匹配項目。"
         ,error_best_results: "如欲得到最佳結果，請嘗試輸入您物業的賬號。"
-        ,error_should_have_worked: "如果您認為此法應當奏效，您可嘗試在 <a href=\"http://opa.phila.gov/opa.apps/Search/SearchForm.aspx?url=search\" target=\"_blank\">property.phila.gov</a> 上進行搜尋"
+        ,error_should_have_worked: "如果您認為此法應當奏效，您可嘗試在 <a href=\"http://property.phila.gov/\" target=\"_blank\">http://property.phila.gov/</a> 上進行搜尋"
         ,error_database: "在資料庫中尋找物業時發生一個錯誤。請重試。"
         ,error_verifying: "在驗證地址時發生一個錯誤。請重試。"
         ,error_generic: "發生一個錯誤。請重試。"


### PR DESCRIPTION
This PR disables the search controls on the landing page and adds a banner redirecting users to Property. The rest of the site is fully functional, so no deep bookmarks will be broken.